### PR TITLE
Reduce password validation strictness

### DIFF
--- a/app/Config/Auth.php
+++ b/app/Config/Auth.php
@@ -268,8 +268,8 @@ class Auth extends ShieldAuth
      */
     public array $passwordValidators = [
         CompositionValidator::class,
-        NothingPersonalValidator::class,
-        DictionaryValidator::class,
+        // NothingPersonalValidator::class,
+        // DictionaryValidator::class,
         // PwnedValidator::class,
     ];
 


### PR DESCRIPTION
Remove 
```php
NothingPersonalValidator::class,
DictionaryValidator::class,
```

from `$passwordValidators`


```php
public array $passwordValidators = [
    CompositionValidator::class,
    // NothingPersonalValidator::class,
    // DictionaryValidator::class,
    // PwnedValidator::class,
];
```